### PR TITLE
Use dispatch queues for synchronization

### DIFF
--- a/Task/Graph/TSKGraph.m
+++ b/Task/Graph/TSKGraph.m
@@ -38,6 +38,8 @@
  */
 @property (nonatomic, strong, readonly) NSMutableSet *tasks;
 
+@property (nonatomic, strong, readonly) dispatch_queue_t finishedTasksQueue;
+
 /*!
  @abstract The set of tasks in the graph that have finished successfully.
  @discussion Access to this object is not thread-safe. All accesses to the set should be synchronized
@@ -104,13 +106,17 @@
         // If no operation queue was provided, create one
         if (!operationQueue) {
             operationQueue = [[NSOperationQueue alloc] init];
-            operationQueue.name = [[NSString alloc] initWithFormat:@"com.twotoasters.TSKGraph.operationQueue.%@", name];
+            operationQueue.name = [[NSString alloc] initWithFormat:@"com.twotoasters.TSKGraph.%@", name];
         }
 
         _name = [name copy];
         _operationQueue = operationQueue;
         _tasks = [[NSMutableSet alloc] init];
         _finishedTasks = [[NSMutableSet alloc] init];
+
+        NSString *finishedTasksQueueName = [NSString stringWithFormat:@"com.twotoasters.TSKGraph.%@.finishedTasks", _name];
+        _finishedTasksQueue = dispatch_queue_create([finishedTasksQueueName UTF8String], DISPATCH_QUEUE_CONCURRENT);
+
         _prerequisiteTasks = [NSMapTable strongToStrongObjectsMapTable];
         _dependentTasks = [NSMapTable strongToStrongObjectsMapTable];
     }
@@ -214,9 +220,12 @@
 
 - (BOOL)hasUnfinishedTasks
 {
-    @synchronized (self.finishedTasks) {
-        return [self.tasksWithNoDependentTasks isSubsetOfSet:self.finishedTasks];
-    }
+    __block BOOL isSubset = NO;
+    dispatch_sync(self.finishedTasksQueue, ^{
+        isSubset = [self.tasksWithNoDependentTasks isSubsetOfSet:self.finishedTasks];
+    });
+
+    return isSubset;
 }
 
 
@@ -231,35 +240,6 @@
     return NO;
 }
 
-
-#pragma mark - Subtask State
-
-- (void)subtask:(TSKTask *)task didFinishWithResult:(id)result
-{
-    @synchronized (self.finishedTasks) {
-        [self.finishedTasks addObject:task];
-
-        if ([self.delegate respondsToSelector:@selector(graphDidFinish:)] && [self.tasksWithNoDependentTasks isSubsetOfSet:self.finishedTasks]) {
-            [self.delegate graphDidFinish:self];
-        }
-    }
-}
-
-
-- (void)subtask:(TSKTask *)task didFailWithError:(NSError *)error
-{
-    if ([self.delegate respondsToSelector:@selector(task:inGraph:didFailWithError:)]) {
-        [self.delegate task:task inGraph:self didFailWithError:error];
-    }
-}
-
-
-- (void)subtaskDidReset:(TSKTask *)task
-{
-    @synchronized (self.finishedTasks) {
-        [self.finishedTasks removeObject:task];
-    }
-}
 
 #pragma mark -
 
@@ -278,6 +258,36 @@
 - (void)retry
 {
     [self.tasksWithNoPrerequisiteTasks makeObjectsPerformSelector:@selector(retry)];
+}
+
+
+#pragma mark - Subtask State
+
+- (void)subtask:(TSKTask *)task didFinishWithResult:(id)result
+{
+    dispatch_barrier_async(self.finishedTasksQueue, ^{
+        [self.finishedTasks addObject:task];
+    });
+
+    if ([self.delegate respondsToSelector:@selector(graphDidFinish:)] && [self hasUnfinishedTasks]) {
+        [self.delegate graphDidFinish:self];
+    }
+}
+
+
+- (void)subtask:(TSKTask *)task didFailWithError:(NSError *)error
+{
+    if ([self.delegate respondsToSelector:@selector(task:inGraph:didFailWithError:)]) {
+        [self.delegate task:task inGraph:self didFailWithError:error];
+    }
+}
+
+
+- (void)subtaskDidReset:(TSKTask *)task
+{
+    dispatch_barrier_async(self.finishedTasksQueue, ^{
+        [self.finishedTasks removeObject:task];
+    });
 }
 
 @end

--- a/Task/Tasks/TSKTask.m
+++ b/Task/Tasks/TSKTask.m
@@ -65,10 +65,11 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
 @property (nonatomic, strong, readwrite) id result;
 
 /*!
- @abstract A lock to control changes to task state.
- @discussion This lock is only used within -transitionFromStateInSet:toState:andExecuteBlock:.
+ @abstract A dispatch queue to control changes to task state.
+ @discussion This queue is only used within -transitionFromStateInSet:toState:andExecuteBlock: to 
+     perform data synchronization.
  */
-@property (nonatomic, strong, readonly) NSLock *stateLock;
+@property (nonatomic, strong, readonly) dispatch_queue_t stateQueue;
 
 /*!
  @abstract If the receiver’s state is in the specified set of from-states, transitions to the specified
@@ -123,7 +124,8 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
 
         _name = [name copy];
         _state = TSKTaskStateReady;
-        _stateLock = [[NSLock alloc] init];
+        NSString *stateQueueName = [NSString stringWithFormat:@"com.twotoasters.TSKTask.%@.state", name];
+        _stateQueue = dispatch_queue_create([stateQueueName UTF8String], DISPATCH_QUEUE_SERIAL);
     }
 
     return self;
@@ -183,13 +185,13 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
 
 + (BOOL)automaticallyNotifiesObserversOfState
 {
-    // This avoids a deadlock condition in -transitionFromStateInSet:toState:andExecuteBlock: in
-    // which the stateLock is locked, but KVO observers are notified of the change before the lock
-    // can be unlocked. This is a problem when, e.g., upon task failure, a KVO observer is notified
-    // on the same thread as the aforementioned method. If the KVO observer immediately sends the
-    // task -retry, that message will result in -transitionFromStateInSet:toState:andExecuteBlock:
-    // being invoked again before the stateLock from the original invocation can be unlocked, thus
-    // resulting in deadlock.
+    // This avoids a deadlock condition in -transitionFromStateInSet:toState:andExecuteBlock: in which
+    // the stateQueue is in use, but KVO observers are notified of the change before the state transition
+    // block exits the queue. This is a problem when, e.g., upon task failure, a KVO observer is notified
+    // on the same thread as the aforementioned method. If the KVO observer immediately sends the task
+    // -retry, that message will result in -transitionFromStateInSet:toState:andExecuteBlock: being
+    // invoked again before the block from the original invocation exits the stateQueue, thus resulting
+    // in deadlock.
     return NO;
 }
 
@@ -259,32 +261,30 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
     //
     //     Failed -> Pending: Task is retried (-retry) or reset (-reset)
 
-    // Get the state lock. If the current state is not in the set of valid from-states, just unlock
-    // and return.
-    [self.stateLock lock];
-    if (![validFromStates containsObject:@(self.state)]) {
-        [self.stateLock unlock];
-        return;
-    }
+    __block BOOL didTransition = NO;
+    dispatch_sync(self.stateQueue, ^{
+        // If the current state is not in the set of valid from-states, we have nothing to do
+        if (![validFromStates containsObject:@(self.state)]) {
+            return;
+        }
 
-    // Otherwise, if the from-state and the to-state differ, change the state. Do not use the
-    // built-in accessor, as that will trigger KVO notifications, which we do not want. See the
-    // explanatory comments in +automaticallyNotifiesObserversOfState.
-    TSKTaskState fromState = self.state;
-    if (fromState != toState) {
-        [self willChangeValueForKey:@"state"];
-        _state = toState;
-    }
+        // Otherwise, if the from-state and the to-state differ, change the state. We should avoid triggering
+        // KVO notifications. See the explanatory comments in +automaticallyNotifiesObserversOfState.
+        TSKTaskState fromState = self.state;
+        if (fromState != toState) {
+            [self willChangeValueForKey:@"state"];
+            _state = toState;
+            didTransition = YES;
+        }
+    });
 
-    // Only after we have unlocked the state lock should we mark the state as changed
-    [self.stateLock unlock];
-    if (fromState != toState) {
+    if (didTransition) {
         [self didChangeValueForKey:@"state"];
-    }
 
-    // Only once all KVO notifications have fired should we execute the block
-    if (block) {
-        block();
+        // Only once all KVO notifications have fired should we execute the block
+        if (block) {
+            block();
+        }
     }
 }
 


### PR DESCRIPTION
Switch from using `@synchronized` and `NSLock` for synchronization to using dispatch queues.
- Instead of mutual exclusion with `NSLock`, use a serial queue and `dispatch_sync` around critical sections.
- Instead of `@synchronized` for mutable object synchronization, use a concurrent queue with `dispatch_sync` around reads and `dispatch_barrier_async` around writes.

@jnjosh Please review. This is arguably better than before. It’s very slightly more performant, but more importantly, it’s consistent. Also, merge this before pull request #3 (task graph completion).
