### PR TITLE
Add operation queue for tasks

### DIFF
--- a/Task.podspec
+++ b/Task.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Task"
-  s.version      = "0.2"
+  s.version      = "0.3"
 
   s.summary      = <<-SUMMARY
                    A simple Cocoa framework for representing interdependent units of work.

--- a/Task/Tasks/TSKTask.h
+++ b/Task/Tasks/TSKTask.h
@@ -101,6 +101,12 @@ extern NSString *const TSKTaskStateDescription(TSKTaskState state);
 /*! The task’s delegate. */
 @property (nonatomic, weak) id<TSKTaskDelegate> delegate;
 
+/*!
+ @abstract The task’s operation queue.
+ @discussion If not explicitly set, the task’s queue will be the same as its graph’s.
+ */
+@property (nonatomic, strong) NSOperationQueue *operationQueue;
+
 /*! 
  @abstract The task’s graph. 
  @discussion This property is set when the task is added to a graph. Once a task has been added to a

--- a/Task/Tasks/TSKTask.m
+++ b/Task/Tasks/TSKTask.m
@@ -181,6 +181,12 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
 }
 
 
+- (NSOperationQueue *)operationQueue
+{
+    return _operationQueue ? _operationQueue : self.graph.operationQueue;
+}
+
+
 #pragma mark - States
 
 + (BOOL)automaticallyNotifiesObserversOfState
@@ -321,7 +327,7 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
     // task has already been marked cancelled. This shouldn’t be an issue, since -main should be
     // checking if the task is cancelled and exiting as soon as possible, but that’s not always
     // possible. Doing the check inside the operation’s block before invoking -main avoids that.
-    [self.graph.operationQueue addOperationWithBlock:^{
+    [self.operationQueue addOperationWithBlock:^{
         [self transitionFromState:TSKTaskStateReady toState:TSKTaskStateExecuting andExecuteBlock:^{
             [self main];
         }];


### PR DESCRIPTION
Just adds an `operationQueue` property to `TSKTask`, which can be used to give tasks operation queues separate from their graph’s.

@macdrevx @jnjosh Please review.
