### PR TITLE
Prevent multiple graphDidFinish: invocations

### DIFF
--- a/Task/Graph/TSKGraph.m
+++ b/Task/Graph/TSKGraph.m
@@ -265,11 +265,13 @@
 
 - (void)subtask:(TSKTask *)task didFinishWithResult:(id)result
 {
-    dispatch_barrier_async(self.finishedTasksQueue, ^{
+    __block BOOL allTasksFinished = NO;
+    dispatch_barrier_sync(self.finishedTasksQueue, ^{
         [self.finishedTasks addObject:task];
+        allTasksFinished = [self.tasksWithNoDependentTasks isSubsetOfSet:self.finishedTasks];
     });
 
-    if ([self.delegate respondsToSelector:@selector(graphDidFinish:)] && ![self hasUnfinishedTasks]) {
+    if ([self.delegate respondsToSelector:@selector(graphDidFinish:)] && allTasksFinished) {
         [self.delegate graphDidFinish:self];
     }
 }


### PR DESCRIPTION
In - [TSKGraph subtask:didFinishWithResult:], we need to check that the graph is finished before we exit the barrier block. Otherwise graphDidFinish: can be invoked multiple times.

@jnjosh Please review.
