### PR TITLE
Add TSKTask subclass interface

### DIFF
--- a/Task/Tasks/TSKTask.h
+++ b/Task/Tasks/TSKTask.h
@@ -352,6 +352,60 @@ extern NSString *const TSKTaskDidStartNotification;
 @end
 
 
+/*!
+ The SubclassInterface contains methods for use by TSKTask subclasses. These methods should never be
+ invoked directly.
+ */
+@interface TSKTask (SubclassInterface)
+
+/*!
+ @abstract Performs actions once the receiver has been cancelled.
+ @discussion This method is invoked after the receiver has been put in the cancelled state but
+     before it has informed its delegate or posted any relevant notifications. The default
+     implementation does nothing. Subclasses can override this method to perform any special actions
+     upon cancellation. This method should not be invoked directly.
+ */
+- (void)didCancel;
+
+/*!
+ @abstract Performs actions once the receiver has been reset.
+ @discussion This method is invoked after the receiver has been put in the pending state but before
+     it has informed its delegate or posted any relevant notifications. The default implementation
+     does nothing. Subclasses can override this method to perform any special actions upon being
+     reset. This method should not be invoked directly.
+ */
+- (void)didReset;
+
+/*!
+ @abstract Performs actions once the receiver has been retried.
+ @discussion This method is invoked after the receiver has been put in the pending state but before
+     it has informed its delegate or posted any relevant notifications. The default implementation
+     does nothing. Subclasses can override this method to perform any special actions upon being
+     retried. This method should not be invoked directly.
+ */
+- (void)didRetry;
+
+/*!
+ @abstract Performs actions once the receiver finishes.
+ @discussion This method is invoked after the receiver has been put in the finished state but before
+     it has informed its delegate or posted any relevant notifications. The default implementation
+     does nothing. Subclasses can override this method to perform any special actions upon finishing.
+     This method should not be invoked directly.
+ */
+- (void)didFinishWithResult:(id)result;
+
+/*!
+ @abstract Performs actions once the receiver has failed.
+ @discussion This method is invoked after the receiver has been put in the failed state but before
+     it has informed its delegate or posted any relevant notifications. The default implementation
+     does nothing. Subclasses can override this method to perform any special actions upon failing.
+     This method should not be invoked directly.
+ */
+- (void)didFailWithError:(NSError *)error;
+
+@end
+
+
 #pragma mark - Task Delegate Protocol
 
 /*!

--- a/Task/Tasks/TSKTask.m
+++ b/Task/Tasks/TSKTask.m
@@ -392,6 +392,8 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
     });
 
     [self transitionFromStateInSet:fromStates toState:TSKTaskStateCancelled andExecuteBlock:^{
+        [self didCancel];
+
         if ([self.delegate respondsToSelector:@selector(taskDidCancel:)]) {
             [self.delegate taskDidCancel:self];
         }
@@ -401,6 +403,11 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
     }];
     
     [self.dependentTasks makeObjectsPerformSelector:@selector(cancel)];
+}
+
+
+- (void)didCancel
+{
 }
 
 
@@ -416,12 +423,20 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
         self.finishDate = nil;
         self.result = nil;
         self.error = nil;
-        [self.workflow subtaskDidReset:self];
+
+        [self didReset];
+
         [self.workflow.notificationCenter postNotificationName:TSKTaskDidResetNotification object:self];
+        [self.workflow subtaskDidReset:self];
         [self transitionToReadyStateAndExecuteBlock:nil];
-    }];
+}];
 
     [self.dependentTasks makeObjectsPerformSelector:@selector(reset)];
+}
+
+
+- (void)didReset
+{
 }
 
 
@@ -437,11 +452,20 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
         self.finishDate = nil;
         self.result = nil;
         self.error = nil;
+
+        [self didRetry];
+
         [self.workflow.notificationCenter postNotificationName:TSKTaskDidRetryNotification object:self];
         [self startIfReady];
+
     }];
 
     [self.dependentTasks makeObjectsPerformSelector:@selector(retry)];
+}
+
+
+- (void)didRetry
+{
 }
 
 
@@ -450,6 +474,8 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
     [self transitionFromState:TSKTaskStateExecuting toState:TSKTaskStateFinished andExecuteBlock:^{
         self.finishDate = [NSDate date];
         self.result = result;
+
+        [self didFinishWithResult:result];
 
         if ([self.delegate respondsToSelector:@selector(task:didFinishWithResult:)]) {
             [self.delegate task:self didFinishWithResult:result];
@@ -462,11 +488,18 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
 }
 
 
+- (void)didFinishWithResult:(id)result
+{
+}
+
+
 - (void)failWithError:(NSError *)error
 {
     [self transitionFromState:TSKTaskStateExecuting toState:TSKTaskStateFailed andExecuteBlock:^{
         self.finishDate = [NSDate date];
         self.error = error;
+
+        [self didFailWithError:error];
 
         if ([self.delegate respondsToSelector:@selector(task:didFailWithError:)]) {
             [self.delegate task:self didFailWithError:error];
@@ -475,6 +508,11 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
         [self.workflow.notificationCenter postNotificationName:TSKTaskDidFailNotification object:self];
         [self.workflow subtask:self didFailWithError:error];
     }];
+}
+
+
+- (void)didFailWithError:(NSError *)error
+{
 }
 
 

--- a/Task/Tasks/TSKTask.m
+++ b/Task/Tasks/TSKTask.m
@@ -457,7 +457,6 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
 
         [self.workflow.notificationCenter postNotificationName:TSKTaskDidRetryNotification object:self];
         [self startIfReady];
-
     }];
 
     [self.dependentTasks makeObjectsPerformSelector:@selector(retry)];


### PR DESCRIPTION
The initial subclass interface only contains did* methods, which do nothing. These are useful for subclasses who wish to react to certain state changes.

@jnjosh Please review.