### PR TITLE
Fix Ready state error

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ workflows.
 ## What’s New in 1.1
 
 Task 1.1 is a significant update that makes it easier for Task subclasses to get prerequisite
-results and respond to state changes.
+results and respond to state changes. It also contains a very important fix related to task
+resetting. Users are strongly encouraged to upgrade to Task 1.1.
+
 
 ### Keyed Prerequisites
 
@@ -60,6 +62,19 @@ While the default implementations of these methods do nothing, subclasses can ov
 perform necessary actions upon state changes. This should obviate the need for `TSKTask` subclasses
 to observe notifications posted by their superclass.
 
+
+### Fix to Reset
+
+Task 1.0 contains a serious bug in which a reset task may be able to run even if its prerequisites
+have not all completed. This bug can be reproduced as follows:
+
+1. Set up a workflow with two tasks, A and B, with A listed as a prerequisite of B.
+2. Run the workflow to completion.
+3. Reset B. A is now in the Finished state. B should be Ready.
+4. Reset A. A is now in the Ready state. As such, B should be in the Pending state.
+
+In Task 1.0, B will be in the Ready state. Task 1.1 fixes this.
+ 
 
 ## Features
 

--- a/Task/Tasks/TSKTask.h
+++ b/Task/Tasks/TSKTask.h
@@ -334,7 +334,7 @@ extern NSString *const TSKTaskDidStartNotification;
 - (void)cancel __attribute__((objc_requires_super));
 
 /*!
- @abstract Sets the task’s state to pending if it is executing, finished, failed, or cancelled.
+ @abstract Sets the task’s state to pending if it is ready, executing, finished, failed, or cancelled.
  @discussion If, after being reset, the receiver’s prerequisite tasks have all finished successfully,
      the receiver is automatically put into the ready state. Regardless of the receiver’s state,
      sends the ‑reset message to all of the receiver’s dependent tasks.

--- a/Task/Tasks/TSKTask.m
+++ b/Task/Tasks/TSKTask.m
@@ -285,7 +285,9 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
     //     Pending -> Ready: All of task’s prerequisite tasks are finished (-transitionToReadyStateAndExecuteBlock:)
     //     Pending -> Cancelled: Task is cancelled (-cancel)
     //
-    //     Ready -> Pending: Task is added to a workflow with at least one prerequisite task (-didAddPrerequisiteTask)
+    //     Ready -> Pending: Task is added to a workflow with at least one prerequisite task (-didAddPrerequisiteTask),
+    //                       or Task is reset (-reset) and has an unfinished prerequisite (because the prerequisite
+    //                       also received -reset)
     //     Ready -> Executing: Task starts (-start)
     //     Ready -> Cancelled: Task is cancelled (-cancel)
     //

--- a/Task/Tasks/TSKTask.m
+++ b/Task/Tasks/TSKTask.m
@@ -434,7 +434,8 @@ NSString *const TSKTaskStateDescription(TSKTaskState state)
     static NSSet *fromStates = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        fromStates = [[NSSet alloc] initWithObjects:@(TSKTaskStateExecuting), @(TSKTaskStateFinished), @(TSKTaskStateFailed), @(TSKTaskStateCancelled), nil];
+        fromStates = [[NSSet alloc] initWithArray:@[ @(TSKTaskStateReady), @(TSKTaskStateExecuting), @(TSKTaskStateFinished),
+                                                     @(TSKTaskStateFailed), @(TSKTaskStateCancelled) ]];
     });
 
     [self transitionFromStateInSet:fromStates toState:TSKTaskStatePending andExecuteBlock:^{


### PR DESCRIPTION
When a dependent task is in the ready state and one of its prerequisites is reset, the dependent task is not moved into pending state. This is because we don't reset ready tasks. This is a bug, as a dependent task can run without its prerequisite being finished.

@mikehaytm Please review.